### PR TITLE
Allow booting ext4, and add LG7n and LG8n to the filter list

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -6,7 +6,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter Infinix-X678B Infinix-X6833B TECNO-CK7n TECNO-LH7n Infinix-X676C,$(TARGET_DEVICE)),)
+ifneq ($(filter Infinix-X678B Infinix-X6833B TECNO-LG8n TECNO-LG7n TECNO-CK7n TECNO-LH7n Infinix-X676C,$(TARGET_DEVICE)),)
 
 include $(call all-subdir-makefiles,$(LOCAL_PATH))
 

--- a/recovery/root/first_stage_ramdisk/fstab.mt6789
+++ b/recovery/root/first_stage_ramdisk/fstab.mt6789
@@ -7,18 +7,17 @@
 # 1 "vendor/mediatek/proprietary/hardware/fstab/mt6789/fstab.in.mt6789" 2
 # 172 "vendor/mediatek/proprietary/hardware/fstab/mt6789/fstab.in.mt6789"
 system /system erofs ro wait,slotselect,logical,first_stage_mount,avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey
-
-
 system /system ext4 ro wait,slotselect,logical,first_stage_mount,avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey
 
 
 system_ext /system_ext erofs ro wait,slotselect,logical,first_stage_mount,avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey
+system_ext /system_ext ext4 ro wait,slotselect,logical,first_stage_mount,avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey
 
 vendor /vendor erofs ro wait,slotselect,logical,first_stage_mount
-
+vendor /vendor ext4 ro wait,slotselect,logical,first_stage_mount
 
 product /product erofs ro wait,slotselect,logical,first_stage_mount
-
+product /product ext4 ro wait,slotselect,logical,first_stage_mount
 
 
 

--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -7,8 +7,11 @@
 system				/system			erofs		ro																	wait,slotselect,logical
 system				/system			ext4		ro																	wait,slotselect,logical
 vendor				/vendor			erofs		ro																	wait,slotselect,logical
+vendor				/vendor			ext4		ro																	wait,slotselect,logical
 product				/product		erofs		ro																	wait,slotselect,logical
+product				/product		ext4		ro																	wait,slotselect,logical
 system_ext			/system_ext		erofs		ro																	wait,slotselect,logical
+system_ext			/system_ext		ext4		ro																	wait,slotselect,logical
 vendor_dlkm			/vendor_dlkm		ext4		ro																	wait,slotselect,logical
 odm_dlkm			/odm_dlkm		ext4		ro																	wait,slotselect,logical
 tr_mi				/tr_mi			ext4		ro																	wait,slotselect,logical,nofail


### PR DESCRIPTION
Right now Custom ROMs that are built with ext4(LineageOS and other roms built without GApps) instead of erofs fails booting due to missing ext4 mount options

This fixes that issue and allow Ext4 Custom ROMs to boot