### PR TITLE
mt6789-common: Allow mounting erofs {odm,vendor}_dlkm partitions

### DIFF
--- a/recovery/root/first_stage_ramdisk/fstab.mt6789
+++ b/recovery/root/first_stage_ramdisk/fstab.mt6789
@@ -22,9 +22,11 @@ product /product ext4 ro wait,slotselect,logical,first_stage_mount
 
 
 
+vendor_dlkm /vendor_dlkm erofs ro wait,slotselect,logical,first_stage_mount
 vendor_dlkm /vendor_dlkm ext4 ro wait,slotselect,logical,first_stage_mount
 
 
+odm_dlkm /odm_dlkm erofs ro wait,slotselect,logical,first_stage_mount
 odm_dlkm /odm_dlkm ext4 ro wait,slotselect,logical,first_stage_mount
 
 

--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -12,7 +12,9 @@ product				/product		erofs		ro																	wait,slotselect,logical
 product				/product		ext4		ro																	wait,slotselect,logical
 system_ext			/system_ext		erofs		ro																	wait,slotselect,logical
 system_ext			/system_ext		ext4		ro																	wait,slotselect,logical
+vendor_dlkm			/vendor_dlkm		erofs		ro																	wait,slotselect,logical
 vendor_dlkm			/vendor_dlkm		ext4		ro																	wait,slotselect,logical
+odm_dlkm			/odm_dlkm		erofs		ro																	wait,slotselect,logical
 odm_dlkm			/odm_dlkm		ext4		ro																	wait,slotselect,logical
 tr_mi				/tr_mi			ext4		ro																	wait,slotselect,logical,nofail
 tr_theme			/tr_theme		ext4		ro																	wait,slotselect,logical,nofail


### PR DESCRIPTION
This fixes booting on Android 16 ROMs for LG7n/LG8n and LH7n after moving dlkm partitions to erofs

* Commit https://github.com/Anything-at-25-00/android_device_tecno_mt6789-common/commit/89899965a0dc1698face2328bf0fb52adb6a3690 broke booting with OrangeFox
* Let's allow mounting erofs dlkm partitions to fix booting on LG7n/LG8n/LH7n Android 16 ROMs